### PR TITLE
Re-adds geSuitHomes as dependency for TrustedHomes

### DIFF
--- a/Pandora.iml
+++ b/Pandora.iml
@@ -1,15 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="4">
-  <component name="CheckStyle-IDEA-Module">
-    <option name="configuration">
-      <map />
-    </option>
-  </component>
   <component name="FacetManager">
     <facet type="minecraft" name="Minecraft">
       <configuration>
         <autoDetectTypes>
           <platformType>SPIGOT</platformType>
+          <platformType>BUKKIT</platformType>
         </autoDetectTypes>
       </configuration>
     </facet>

--- a/src/au/com/addstar/pandora/MasterPlugin.java
+++ b/src/au/com/addstar/pandora/MasterPlugin.java
@@ -76,7 +76,9 @@ public class MasterPlugin extends JavaPlugin {
 
     private void registerModules() {
         // TrustedHomes also depends on geSuitHomes; explicit dependency removed due to the Redis refactor of geSuit
-        registerModule("TrustedHomes", "au.com.addstar.pandora.modules.TrustedHomes","GriefPrevention");
+        // Re-added geSuitHomes under auth slack-adnap/add5tar dated:230722I1525 "thats fine, ignore that"
+        registerModule("TrustedHomes", "au.com.addstar.pandora.modules.TrustedHomes",
+                "GriefPrevention", "geSuitHomes");
         registerModule("Quickshop-Griefprevention-Interop", "au.com.addstar.pandora.modules.QuickshopGPInterop",
                 "GriefPrevention", "QuickShop");
         registerModule("Vanish-Citizens-Interop", "au.com.addstar.pandora.modules.VanishCitizensIO",

--- a/src/resources/plugin.yml
+++ b/src/resources/plugin.yml
@@ -5,7 +5,7 @@ description: ${project.description}
 
 main: ${mainClass}
 
-softdepend: [Multiverse-Core, My_Worlds, GriefPrevention, QuickShop, VanishNoPacket, Citizens, Votifier, Monolith, Minigames, MurderMystery, BuildBattle, VillageDefense, PrisonMines, ChatControlRed, RPlace]
+softdepend: [geSuitHomes, Multiverse-Core, My_Worlds, GriefPrevention, QuickShop, VanishNoPacket, Citizens, Votifier, Monolith, Minigames, MurderMystery, BuildBattle, VillageDefense, PrisonMines, ChatControlRed, RPlace]
 
 loadbefore: [CommandHelper]
 


### PR DESCRIPTION
1.20 appears to change the order of when geSuitHomes was loaded, and was loading after Pandora. Thus an error was occuring for TrustedHomes module. This adds soft dependency and dependency in TrustedHomes for geSuitHomes.