### PR TITLE
Adds Treasures as softdepend

### DIFF
--- a/src/resources/plugin.yml
+++ b/src/resources/plugin.yml
@@ -5,7 +5,7 @@ description: ${project.description}
 
 main: ${mainClass}
 
-softdepend: [geSuitHomes, Multiverse-Core, My_Worlds, GriefPrevention, QuickShop, VanishNoPacket, Citizens, Votifier, Monolith, Minigames, MurderMystery, BuildBattle, VillageDefense, PrisonMines, ChatControlRed, RPlace, Konquest]
+softdepend: [geSuitHomes, Multiverse-Core, My_Worlds, GriefPrevention, QuickShop, VanishNoPacket, Citizens, Votifier, Monolith, Minigames, MurderMystery, BuildBattle, VillageDefense, PrisonMines, ChatControlRed, RPlace, Konquest, Treasures]
 
 loadbefore: [CommandHelper]
 


### PR DESCRIPTION
Treasures was never added as a soft dep, but appeared to work fine without it until 1.20+