### PR TITLE
Fix typo in AutoConfig

### DIFF
--- a/src/au/com/addstar/pandora/AutoConfig.java
+++ b/src/au/com/addstar/pandora/AutoConfig.java
@@ -193,7 +193,7 @@ public abstract class AutoConfig {
                             throw new IllegalArgumentException("Cannot use type " + field.getType().getSimpleName() + "<" + type.toString() + "> for AutoConfiguration");   //$NON-NLS-2$ //$NON-NLS-2$
                     } else if (Set.class.isAssignableFrom(field.getType())) {
                         if (field.getGenericType() == null)
-                            throw new IllegalArgumentException("Cannot use type set without specifying generic type for AytoConfiguration");
+                            throw new IllegalArgumentException("Cannot use type set without specifying generic type for AutoConfiguration");
 
                         Type type = ((ParameterizedType) field.getGenericType()).getActualTypeArguments()[0];
 


### PR DESCRIPTION
## Summary
- fix typo `AytoConfiguration` -> `AutoConfiguration`

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425f101f2c832cb9798a08025ec8f0