### PR TITLE
Fix log typo in TreasuresHelper

### DIFF
--- a/src/au/com/addstar/pandora/modules/TreasuresHelper.java
+++ b/src/au/com/addstar/pandora/modules/TreasuresHelper.java
@@ -86,7 +86,7 @@ public class TreasuresHelper implements Module, Listener {
         // Broadcast the message across other servers
         mPlugin.sendChatControlMessage(Bukkit.getConsoleSender(), mConfig.broadcast_channel, msg);
         if (mConfig.verboseChests)
-            mPlugin.getLogger().info(event.getPlayer().getDisplayName() + " recieved a  " + event.getRewardName() + "( " + event.getRarity() + ")");
+            mPlugin.getLogger().info(event.getPlayer().getDisplayName() + " received a  " + event.getRewardName() + "( " + event.getRarity() + ")");
     }
 
     private class Config extends AutoConfig {


### PR DESCRIPTION
## Summary
- fix a spelling error in a TreasuresHelper log message

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425ef38848832c99cdac05679ff87d