### PR TITLE
Add SpawnFixer module

### DIFF
--- a/src/au/com/addstar/pandora/MasterPlugin.java
+++ b/src/au/com/addstar/pandora/MasterPlugin.java
@@ -126,6 +126,7 @@ public class MasterPlugin extends JavaPlugin {
         registerModule("ChatControlHelper", "au.com.addstar.pandora.modules.ChatControlHelper", "ChatControl");
         registerModule("StaffChat", "au.com.addstar.pandora.modules.StaffChat", "ChatControl");
         registerModule("RPlaceDynmap", "au.com.addstar.pandora.modules.RPlaceDynmap", "dynmap", "RPlace");
+        registerModule("SpawnFixer", "au.com.addstar.pandora.modules.SpawnFixer");
         registerModule("Konquest", "au.com.addstar.pandora.modules.Konquest", "Konquest");
         registerModule("MineChessHelper", "au.com.addstar.pandora.modules.MineChessHelper","MineChessPlus", "ChatControl");
     }

--- a/src/au/com/addstar/pandora/modules/SpawnFixer.java
+++ b/src/au/com/addstar/pandora/modules/SpawnFixer.java
@@ -1,0 +1,56 @@
+package au.com.addstar.pandora.modules;
+
+import au.com.addstar.pandora.AutoConfig;
+import au.com.addstar.pandora.ConfigField;
+import au.com.addstar.pandora.MasterPlugin;
+import au.com.addstar.pandora.Module;
+import org.bukkit.Location;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.spigotmc.event.player.PlayerSpawnLocationEvent;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashSet;
+
+public class SpawnFixer implements Module, Listener {
+    private MasterPlugin plugin;
+    private Config config;
+
+    @Override
+    public void onEnable() {
+        if (config.load())
+            config.save();
+    }
+
+    @Override
+    public void onDisable() {
+    }
+
+    @Override
+    public void setPandoraInstance(MasterPlugin plugin) {
+        this.plugin = plugin;
+        this.config = new Config(new File(plugin.getDataFolder(), "SpawnFixer.yml"));
+    }
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void onSpawn(PlayerSpawnLocationEvent event) {
+        Location spawn = event.getSpawnLocation();
+        if (spawn == null)
+            return;
+        String worldName = spawn.getWorld().getName();
+        if (config.worlds.contains(worldName)) {
+            event.setSpawnLocation(spawn.getWorld().getSpawnLocation());
+        }
+    }
+
+    private static class Config extends AutoConfig {
+        public Config(File file) {
+            super(file);
+        }
+
+        @ConfigField(name = "whitelisted-worlds", comment = "Worlds that should always spawn players at world spawn")
+        public HashSet<String> worlds = new HashSet<>(Arrays.asList("hub"));
+    }
+}


### PR DESCRIPTION
## Summary
- add new `SpawnFixer` module to ensure players spawn at world spawn for specific worlds
- register the module in `MasterPlugin`

## Testing
- `apt-get update` *(fails: repository signatures not available)*
- `javac -version`

------
https://chatgpt.com/codex/tasks/task_e_6873974d463c832c81c2889f8fa703e9